### PR TITLE
bump version to 0.4

### DIFF
--- a/.github/workflows/CLI_linuxBuild.yml
+++ b/.github/workflows/CLI_linuxBuild.yml
@@ -31,8 +31,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v0.3.${{ github.run_number }}
-          release_name: Monocle Linux CLI v0.3.${{ github.run_number }}
+          tag_name: v0.4.${{ github.run_number }}
+          release_name: Monocle Linux CLI v0.4.${{ github.run_number }}
           body: ""
           draft: false
           prerelease: false

--- a/.github/workflows/CLI_winBuild.yml
+++ b/.github/workflows/CLI_winBuild.yml
@@ -32,8 +32,8 @@ jobs:
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-          tag_name: v0.3.${{ github.run_number }}
-          release_name: Monocle Win CLI v0.3.${{ github.run_number }}
+          tag_name: v0.4.${{ github.run_number }}
+          release_name: Monocle Win CLI v0.4.${{ github.run_number }}
           body: ""
           draft: false
           prerelease: false

--- a/.github/workflows/UI_winBuild.yml
+++ b/.github/workflows/UI_winBuild.yml
@@ -36,8 +36,8 @@ jobs:
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-          tag_name: v0.3.${{ github.run_number }}
-          release_name: Monocle Win UI v0.3.${{ github.run_number }}
+          tag_name: v0.4.${{ github.run_number }}
+          release_name: Monocle Win UI v0.4.${{ github.run_number }}
           body: ""
           draft: false
           prerelease: false

--- a/Monocle.CLI/Monocle.CLI.csproj
+++ b/Monocle.CLI/Monocle.CLI.csproj
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>0.3</Version>
+    <Version>0.4</Version>
     <InvariantGlobalization>false</InvariantGlobalization>
   </PropertyGroup>
 


### PR DESCRIPTION
- sets target framework to net6.0
- handles parent scan detection for methods with back to back scans
- Updated mzML writer to use precursor tags compatible with other tools. fixes issue 32
